### PR TITLE
fix: Correct Dockerfile CMD for RunPod execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN conda run -n amphion pip install --no-cache-dir -r requirements.txt
 RUN conda init \
     && echo "\nconda activate amphion\n" >> ~/.bashrc
 
-CMD ["/bin/bash"]
+CMD ["conda", "run", "-n", "amphion", "python", "handler.py"]
 
 # *** Build ***
 # docker build -t realamphion/amphion .


### PR DESCRIPTION
This commit corrects the `CMD` instruction in the Dockerfile to ensure the RunPod serverless handler starts correctly.

The `CMD` has been changed from `["/bin/bash"]` to `["conda", "run", "-n", "amphion", "python", "handler.py"]`.

This new command executes the `handler.py` script using the Python interpreter within the 'amphion' conda environment, which in turn calls `runpod.serverless.start()` to initialize the handler and listen for jobs. This is essential for the proper functioning of the custom Docker image on the RunPod platform.