### PR TITLE
fix: Simplify apt-get sources in Dockerfile for stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,7 @@ ENV PATH=$CONDA_HOME/bin:$CUDA_HOME/bin:$PATH \
     NCCL_HOME=$CUDA_HOME
 
 # Install ubuntu packages
-RUN sed -i 's/archive.ubuntu.com/mirrors.cloud.tencent.com/g' /etc/apt/sources.list \
-    && sed -i 's/security.ubuntu.com/mirrors.cloud.tencent.com/g' /etc/apt/sources.list \
-    && rm /etc/apt/sources.list.d/cuda.list \
-    && apt-get update \
+RUN apt-get update \
     && apt-get -y install \
     python3-pip ffmpeg git less wget libsm6 libxext6 libxrender-dev \
     build-essential cmake pkg-config libx11-dev libatlas-base-dev \


### PR DESCRIPTION
This commit modifies the Dockerfile to improve the reliability of the `apt-get` package installation steps.

Removed the lines that:
- Changed the default Ubuntu mirrors to `mirrors.cloud.tencent.com`.
- Deleted `/etc/apt/sources.list.d/cuda.list`.

The build process will now use the standard Ubuntu and NVIDIA base image repositories, which is expected to be more stable and less prone to mirror-specific or source list modification issues. This addresses a reported build failure (exit code 100) during the `apt-get install` phase.