### PR TITLE
fix: Increase verbosity of pip install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY requirements.txt requirements.txt
 # Consider adding COPY . /app if full context is needed for pip install.
 
 # Install Python packages from requirements.txt into the 'amphion' conda environment
-RUN conda run -n amphion pip install --no-cache-dir -r requirements.txt
+RUN conda run -n amphion pip install -vvv --no-cache-dir -r requirements.txt
 
 RUN conda init \
     && echo "\nconda activate amphion\n" >> ~/.bashrc


### PR DESCRIPTION
This commit modifies the Dockerfile to add the `-vvv` flag to the `pip install -r requirements.txt` command.

This change is intended to provide more detailed output during the Python package installation phase of the Docker build. Increased verbosity will help you diagnose potential issues if the build process hangs or encounters errors while downloading or installing specific packages.